### PR TITLE
Fix overload->overlap typo

### DIFF
--- a/src/content/platformer/step14_en.md
+++ b/src/content/platformer/step14_en.md
@@ -174,7 +174,7 @@ Here's how the whole thing will look like:
     };
     ```
 
-    This time, we have made use of the **filter** function we can pass to `overload`. This is because we don't want the overlap test to pass if the player hasn't fetched the key yet or if the main character is jumping –it would be weird to open a key while jumping, right?
+    This time, we have made use of the **filter** function we can pass to `overlap`. This is because we don't want the overlap test to pass if the player hasn't fetched the key yet or if the main character is jumping –it would be weird to open a key while jumping, right?
 
 1. The collision callback looks like this:
 


### PR DESCRIPTION
The name of the function is 'overlap' and the name of the parameter is 'filter', so I believe the intention is to use overlap, rather than overload.