### PR TITLE
Hide the download title section altogether.

### DIFF
--- a/src/layouts/guide_step.pug
+++ b/src/layouts/guide_step.pug
@@ -1,8 +1,8 @@
 extends default.pug
 
 block extra
-    h2 Download
     if download
+        h2 Download
         p Are you stuck? Take a look at
             = ' '
             a(href=relative(download), download) the source code


### PR DESCRIPTION
E.g. step16 shows an empty section.

https://mozdevs.github.io/html5-games-workshop/en/guides/platformer/moving-forward/